### PR TITLE
Add bash to alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM maven:3.5-jdk-8-alpine
 
-RUN  mvn com.sap.cloud:neo-javaee6-wp-maven-plugin:2.164.4:install-sdk -DsdkInstallPath=sdk -Dincludes=tools/**,license/**,sdk.version && \
+RUN  apk add --no-cache bash && \
+     mvn com.sap.cloud:neo-javaee6-wp-maven-plugin:2.164.4:install-sdk -DsdkInstallPath=sdk -Dincludes=tools/**,license/**,sdk.version && \
      chmod -R 777 sdk && \
      ln -s /sdk/tools/neo.sh /usr/bin/neo.sh && \
      rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Without bash the container won't run on Azure Devops.
cf. [Azure doc](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases?view=azure-devops&tabs=yaml)

This #PR is has been reviewed already [here](https://github.com/SAP/devops-docker-images/pull/109)