### PR TITLE
fix: types as list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Create new Release
 
 on:
   repository_dispatch:
-    types: perform-release
+    types: [perform-release]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
As per example in the [docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#repository_dispatch):

```yaml
on:
  repository_dispatch:
    types: [test_result]
```