### PR TITLE
chore: remove gh registry push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,8 +16,5 @@ jobs:
     - name: Run CI
       run: |
         echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-        echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ secrets.CR_USER }} --password-stdin
         docker build -t ppiper/neo-cli:latest .
-        docker tag ppiper/neo-cli:latest ghcr.io/sap/ppiper-neo-cli:latest
         docker push ppiper/neo-cli:latest
-        docker push ghcr.io/sap/ppiper-neo-cli:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,8 @@ jobs:
       - name: Build and push
         run: |
           echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-          echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ secrets.CR_USER }} --password-stdin
           docker build -t ppiper/neo-cli:${{ env.PIPER_version }} .
-          docker tag ppiper/neo-cli:${{ env.PIPER_version }} ghcr.io/sap/ppiper-neo-cli:${{ env.PIPER_version }}
           docker push ppiper/neo-cli:${{ env.PIPER_version }}
-          docker push ghcr.io/sap/ppiper-neo-cli:${{ env.PIPER_version }}
       - uses: SAP/project-piper-action@master
         with:
           piper-version: latest

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This image is intended to be used in Jenkins pipelines.
 
 ## Download
 
+⚠️ **Important Notice:** The GitHub Container Registry (ghcr.io) for this project is no longer being updated. Please use the Docker Hub registry instead: `docker pull ppiper/neo-cli`
+
 This image is published to Docker Hub and can be pulled via the command
 
 ```


### PR DESCRIPTION
Also remove using gh registry for this image, similar to what we did with the node-browsers repo:
https://github.com/SAP/devops-docker-node-browsers/pull/59