### PR TITLE
chore: remove GitHub Container Registry push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,8 +19,5 @@ jobs:
     - name: Run CI
       run: |
         echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-        echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ secrets.CR_USER }} --password-stdin
         docker build -t ppiper/neo-cli:latest .
-        docker tag ppiper/neo-cli:latest ghcr.io/sap/ppiper-neo-cli:latest
         docker push ppiper/neo-cli:latest
-        docker push ghcr.io/sap/ppiper-neo-cli:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,8 @@ jobs:
       - name: Build and push
         run: |
           echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-          echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ secrets.CR_USER }} --password-stdin
           docker build -t ppiper/neo-cli:${{ env.PIPER_version }} .
-          docker tag ppiper/neo-cli:${{ env.PIPER_version }} ghcr.io/sap/ppiper-neo-cli:${{ env.PIPER_version }}
           docker push ppiper/neo-cli:${{ env.PIPER_version }}
-          docker push ghcr.io/sap/ppiper-neo-cli:${{ env.PIPER_version }}
       - uses: SAP/project-piper-action@master
         with:
           piper-version: latest

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This image is published to Docker Hub and can be pulled via the command
 docker pull ppiper/neo-cli
 ```
 
+**Note:** This image is no longer published to GitHub Container Registry (ghcr.io). Only Docker Hub is supported.
+
 ## Build
 
 To build this image locally, open a terminal in the directory of the Dockerfile an run


### PR DESCRIPTION
Removes ghcr.io push from workflows as CR_PAT and CR_USER secrets have been removed.

Changes:
- Remove ghcr.io login from release.yml and push.yml
- Remove docker tag and push commands for ghcr.io

Only Docker Hub push remains.